### PR TITLE
Don't kill buffers visible in other frames

### DIFF
--- a/buffer-terminator.el
+++ b/buffer-terminator.el
@@ -212,7 +212,7 @@ The message is formatted with the provided arguments ARGS."
 (defun buffer-terminator--buffer-visible-p (buffer)
   "Return non-nil if BUFFER is visible in any window on any frame."
   (when buffer
-    (or (get-buffer-window buffer 'visible)
+    (or (get-buffer-window buffer 0)
         ;; Tab-bar
         (and (bound-and-true-p tab-bar-mode)
              (fboundp 'tab-bar-get-buffer-tab)


### PR DESCRIPTION
So I'm using buffer-terminator.el for a few days and noticed a problem.

I'm using multi-frame setup, where frames are managed by a tiling WM (i3wm). I have a bunch of emacs frames on a few virtual desktops, and I expect that buffer-terminator.el shouldn't kill buffers displayed in some frame, even if the frame is on another desktop, or is not directly visible right now (e.g. if frames are stacked).

However, this check:

```
(get-buffer-window buffer 'visible)
```

returns nil for some of such buffers. Changing `visible` to `0` fixes it for me.

From doc:

```
The optional argument ALL-FRAMES specifies the frames to consider:

- t means consider all windows on all existing frames.

- visible means consider all windows on all visible frames.

- 0 (the number zero) means consider all windows on all visible
    and iconified frames.

- A frame means consider all windows on that frame only.
```

I guess emacs considers some of my frames as "iconified" (though there is no such concept in i3wm).